### PR TITLE
Fix repository link for Prism.Avalonia templates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 <!--[![downloads](https://img.shields.io/nuget/dt/templates.prism.avalonia)](https://www.nuget.org/packages/Templates.Prism.Avalonia/)-->
 [![Current stable version](https://img.shields.io/nuget/v/Templates.Prism.Avalonia.svg)](https://www.nuget.org/packages/Templates.Prism.Avalonia/)
 
-The [Prism.Avalonia Templates](https://github.com/SuessLabs/Prism.Avalonia.Templates/pull/4) is a collection of `dotnet` template files for creating [Prism.Avalonia](https://github.com/AvaloniaCommunity/Prism.Avalonia) apps.
+The [Prism.Avalonia Templates](https://github.com/SuessLabs/Prism.Avalonia.Templates/pull/4) is a collection of `dotnet` template files for creating [Prism.Avalonia](https://github.com/PrismLibrary/Prism)  ([old repo](https://github.com/AvaloniaCommunity/Prism.Avalonia)) apps.
 
 For more information about `dotnet new` templates see [here](https://blogs.msdn.microsoft.com/dotnet/2017/04/02/how-to-create-your-own-templates-for-dotnet-new/).
 


### PR DESCRIPTION
Updated the repository link for Prism.Avalonia and added a note about the old repository.
